### PR TITLE
修改tensorflow已经废弃掉的api

### DIFF
--- a/deep_q_network.py
+++ b/deep_q_network.py
@@ -79,7 +79,7 @@ def trainNetwork(s, readout, h_fc1, sess):
     # define the cost function
     a = tf.placeholder("float", [None, ACTIONS])
     y = tf.placeholder("float", [None])
-    readout_action = tf.reduce_sum(tf.mul(readout, a), reduction_indices=1)
+    readout_action = tf.reduce_sum(tf.multiply(readout, a), reduction_indices=1)
     cost = tf.reduce_mean(tf.square(y - readout_action))
     train_step = tf.train.AdamOptimizer(1e-6).minimize(cost)
 


### PR DESCRIPTION
tensorflow 1.0.0 api 已经废弃掉了tf.mul，现在使用的是 tf.multiply