### PR TITLE
Update deep_q_network.py for Tensorflow 1.0

### DIFF
--- a/deep_q_network.py
+++ b/deep_q_network.py
@@ -79,7 +79,7 @@ def trainNetwork(s, readout, h_fc1, sess):
     # define the cost function
     a = tf.placeholder("float", [None, ACTIONS])
     y = tf.placeholder("float", [None])
-    readout_action = tf.reduce_sum(tf.mul(readout, a), reduction_indices=1)
+    readout_action = tf.reduce_sum(tf.multiply(readout, a), reduction_indices=1)
     cost = tf.reduce_mean(tf.square(y - readout_action))
     train_step = tf.train.AdamOptimizer(1e-6).minimize(cost)
 


### PR DESCRIPTION
"tf.mul, tf.sub and tf.neg are deprecated in favor of tf.multiply, tf.subtract and tf.negative." - see https://github.com/tensorflow/tensorflow/blob/master/RELEASE.md for changes related to "Release 1.0.0".